### PR TITLE
Fix amazon affiliate ID link

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -6,7 +6,7 @@ window.onload = function() {
       function(affiliateId) {
         var path = "/dp/" + asinElement.value;
         if (affiliateId && affiliateId != "") {
-          path = path + "/" + affiliateId;
+          path = path + "/?tag=" + affiliateId;
         }
         window.history.pushState({}, "", path)
       }


### PR DESCRIPTION
I found that generated URLs with amazon affiliate ID may be invalid.

For example:

* Invalid: http://amazon.co.jp/dp/4832244140/your-affiliate-22
* Valid: http://amazon.co.jp/dp/4832244140/?tag=your-affiliate-22

You can check it in below URL.
https://affiliate.amazon.co.jp/gp/associates/network/tools/link-checker/main.html

So this pull-req fixes this problem.